### PR TITLE
update __isset to handle dynamic properties based on EasyConfigEnum

### DIFF
--- a/src/Entity/Config.php
+++ b/src/Entity/Config.php
@@ -125,6 +125,10 @@ class Config
 
     public function __isset($name)
     {
+        if (EasyConfigEnum::tryFrom($name)) {
+            return true;
+        }
+        
         return match ($name) {
             'id' => isset($this->id),
             'key' => isset($this->key),


### PR DESCRIPTION
The EasyConfigCrudController class (in Adeliom\EasyConfigBundle\Controller\Admin) is trying to access individual dynamic properties for each values in EasyConfigEnum.

__isset wasn't properly handling this, resulting in a NoSuchPropertyException